### PR TITLE
new examples

### DIFF
--- a/01_tutorials/assemblies/connector_rooftimber.py
+++ b/01_tutorials/assemblies/connector_rooftimber.py
@@ -1,0 +1,190 @@
+import compas_fea2
+import os
+
+from compas.geometry import Frame, Point, Line
+
+from compas_fea2.model import Model, RectangularSection, ElasticIsotropic, RigidLinkConnector, BeamElement, Part
+from compas_fea2.problem import Problem, StaticStep, LoadCombination
+from compas_fea2.results import DisplacementFieldResults, ReactionFieldResults
+from compas_fea2.units import units
+
+
+#========================================
+# Backend, paths & units
+#========================================
+# Initialisation du plugin et paths
+compas_fea2.set_backend("compas_fea2_castem")
+# compas_fea2.set_backend("compas_fea2_abaqus")
+compas_fea2.POINT_OVERLAP = False
+HERE = os.path.dirname(__file__)
+TEMP = os.path.join(HERE, "..", "temp")
+
+# Unit system
+units = units(system="SI_mm")  # SI units with length in millimeters
+
+# Define an elastic isotropic material (e.g., concrete or steel)
+mat = ElasticIsotropic(
+    E=11 * units("GPa"),  # Young's modulus (30 GPa)
+    v=0,  # Poisson's ratio (dimensionless)
+    density=0 * units("kg/m**3"),  # Density (2400 kg/m³)
+)
+
+#========================================
+# MODEL
+#========================================
+# Define the model
+mdl = Model(name="roof_timber")
+
+# Geometry
+p00 = Point(0, 0, 0)
+p03 = Point(3000, 0, 0)
+p06 = Point(6000, 0, 0)
+p13 = Point(3000, 0, 1000)
+p22 = Point(2000, 0, 2000)
+p24 = Point(4000, 0, 2000)
+p33 = Point(3000, 0, 3000)
+
+# Lines
+lines = [
+    Line(p00, p06), #0 - tie beam
+    Line(p03, p33), #1 -  king post
+    Line(p00, p33), #2 - left principal rafter
+    Line(p33, p06), #3 - right principal rafter
+    Line(p22, p13), #4 - left strut
+    Line(p13, p24) #5 - right strut
+]
+
+# Section
+sec = RectangularSection(
+    w=10 * units.cm,
+    h=30 * units.cm,
+    material=mat
+)
+
+# Constructor for determining the frame of a beam
+def frame_oriented(line, gamma=0):
+    """
+    Determine the local frame of a line according to its direction.
+    The rotation according to the neutral-axis can be changed with the gamma parameters (radian).
+
+    Parameters
+    ----------
+    line : :class: compas.geometry.Line
+            Compas line defining the neutral axis of the beam.
+    
+    gamma : float (optional)
+            Rotation of the frame along the longitudinal axis.
+            If not indicated, gamma is considered null.
+
+    """
+    from math import atan, pi, asin
+    from numpy import sign
+
+    v = line.vector
+    if v.y== 0 :
+        alpha = -pi/2 *sign(v.x)
+        if v.x==0:
+            beta = pi/2
+        else :
+            beta = asin(v.z/v.length)
+    else :
+        alpha = -atan(v.x/v.y) 
+
+        beta = asin(v.z/v.length)*v.y/abs(v.y)
+    
+    f = Frame.from_euler_angles(
+        euler_angles=[alpha , beta, gamma],
+        static=False,
+        axes="zxy",
+        point=line.start,
+    )
+    return f
+
+# part definition from discretizing method
+parts = []
+for line in lines :
+    prt = parts.append(Part.from_compas_lines_discretized([line], 500, BeamElement, sec, frame_oriented(line, gamma=0)))
+mdl.add_parts(parts)
+
+mdl.add_pin_bc(nodes=[parts[0].find_closest_nodes_to_point(p00, 1).sorted[0]])
+
+
+# Definition of the connection between the parts
+#creation of a list with information connections
+connection_data= [
+    #1st part   #2nd part    #common point  #description
+    [0,         1,          p03],           #tie beam/king post
+    [2,         0,          p00],           #left rafter/tie beam
+    [2,         1,          p33],           #left rafter/king post
+    [3,         0,          p06],           #right rafter/tie beam
+    [3,         1,          p33],           #right rafter/king post
+    [4,         1,          p13],           #left strut/king post
+    [2,         4,          p22],           #left strut/left rafter
+    [5,         1,          p13],           #right strut/king post
+    [3,         5,          p24],           #right strut/right rafter
+]
+
+for data in connection_data :
+    connector = parts[data[0]].create_connector_node(parts[data[1]].find_closest_nodes_to_point(data[2], 1).sorted[0])
+    mdl.add_connector(RigidLinkConnector(nodes=connector, dofs="beam"))
+
+# Set boundary conditions and insure out-of-plane stability
+mdl.add_pin_bc(nodes=[parts[0].find_closest_nodes_to_point(p00, 1).sorted[0]])
+mdl.add_rollerXY_bc(nodes=[parts[0].find_closest_nodes_to_point(p06, 1).sorted[0]])
+mdl.add_rollerYZ_bc(nodes=[parts[1].find_closest_nodes_to_point(p33, 1).sorted[0]])
+
+# Visualize the model
+# mdl.show()
+
+#========================================
+# PROBLEM
+#========================================
+# Define the problem
+prb = mdl.add_problem(problem=Problem(name="Roof_Timber"))
+# define a step
+stp = prb.add_step(StaticStep())
+stp.combination = LoadCombination.SLS()
+
+# Add a node pattern to apply a load on node n2
+stp.add_uniform_node_load(
+    nodes=parts[2].nodes+parts[3].nodes,
+    z =-1000 *units.kN,
+    load_case="LL",
+)
+
+# Define the outputs
+stp.add_outputs([DisplacementFieldResults, ReactionFieldResults])
+
+#========================================
+# PROBLEM
+#========================================
+mdl.analyse_and_extract(problems=[prb], path=TEMP, verbose=True)
+
+#========================================
+# RESULTS AND VISUALIZATION
+#========================================
+
+# # Show deformed shape
+#Compas Viewer
+stp.show_deformed(scale_results=10, show_original=0.3, show_loads=0.01)
+
+# TODO Visualization of line element in VEDO
+# viewer = ModelViewer(mdl)
+# viewer.add_node_field_results(
+#     stp.displacement_field, draw_cmap="viridis", draw_vectors=100
+# )
+# viewer.show()
+
+#Reactions
+react = stp.reaction_field
+print("Max/Min reaction forces in X direction [kN]: ", 
+      react.get_limits_component('x')[0].magnitude, "/",
+      react.get_limits_component('x')[1].magnitude)
+print("Max/Min reaction forces in Y direction [kN]: ", 
+      react.get_limits_component('y')[0].magnitude, "/",
+      react.get_limits_component('y')[1].magnitude)
+print("Max/Min reaction forces in Z direction [kN]: ", 
+      react.get_limits_component('z')[0].magnitude, "/",
+      react.get_limits_component('z')[1].magnitude)
+
+#TODO see the section forces

--- a/01_tutorials/assemblies/interface_stackedcubes.py
+++ b/01_tutorials/assemblies/interface_stackedcubes.py
@@ -1,0 +1,114 @@
+import os
+
+from compas.geometry import Box, Vector, Translation
+
+from compas_gmsh.models import ShapeModel
+
+import compas_fea2
+from compas_fea2.model import Model, Part, Interface, HardContactFrictionPenalty, SolidSection, ElasticIsotropic
+from compas_fea2.problem import LoadCombination
+from compas_fea2.results import DisplacementFieldResults, StressFieldResults
+
+from compas_fea2_vedo import ModelViewer
+
+from compas_fea2.units import units
+
+units = units(system="SI")
+
+compas_fea2.set_backend("compas_fea2_abaqus")
+
+HERE = os.path.dirname(__file__)
+DATA = os.path.join(HERE, "..", "data")
+TEMP = os.path.join(HERE, "..", "temp")
+
+mdl = Model(name="stacked_cubes")
+
+# ==============================================================================
+# MODEL 
+# ==============================================================================
+
+# Geometry and mesh with compas.geometry and compas_gmsh
+box1 = Box.from_width_height_depth(1,1,1)
+box1.translate(Vector(0,0,0.5))
+
+model1 = ShapeModel(name='cube1')
+model1.add_box(box1)
+model1.options.mesh.lmin = 0.2
+model1.generate_mesh(3)
+compas_mesh1 = model1.mesh_to_compas()
+
+# Define material and solid section
+mat = ElasticIsotropic(
+E = 0.01 * units.GPa,
+v = 0.2,
+density = 2000 * units("kg/m**3"))
+
+sec = SolidSection(mat)
+
+# Creation of base part
+prt = Part.from_boundary_mesh(
+    compas_mesh1, section=sec, name="cube1"
+)
+mdl.add_part(prt)
+
+# list with the different parts in order of creation 
+parts=[prt]
+
+w = prt.bounding_box.width
+h = prt.bounding_box.height
+
+# Creation of the stacked cubes
+n_cubes = 3
+for i in range(1,n_cubes):
+    compas_mesh2=compas_mesh1.transformed(transformation=Translation.from_vector(vector=Vector(0,0,i*h)))
+    prti= Part.from_boundary_mesh(compas_mesh2, section=sec, name="cube"+str(i+1))
+    mdl.add_part(prti)
+    parts.append(prti)
+
+# Behaviour law for the inteface
+interaction=HardContactFrictionPenalty(mu=30, stiffness=1e7, tolerance=1)
+
+# Behaviour law for the inteface
+for i in range(1,len(parts)):
+    slave_face = parts[i-1].faces.subgroup(lambda n: n.centroid[2] == i*h)
+    master_face = parts[i].faces.subgroup(lambda n: n.centroid[2] == i*h)
+    interface=Interface(master=master_face, slave=slave_face, behavior=interaction)
+    mdl.add_interface(interface)
+
+# Boundaries condition
+fixed_nodes = prt.nodes.subgroup(lambda n: n.z == 0)
+mdl.add_fix_bc(nodes=fixed_nodes)
+
+# ==============================================================================
+# PROBLEM 
+# ==============================================================================
+# static step and combination
+prb = mdl.add_problem(name="SLS")
+stp = prb.add_static_step(load_step=0.05, min_inc_size=0.1)
+stp.combination = LoadCombination.SLS()
+
+# loads : only the top cube is loaded with compression
+stp.add_uniform_node_load(nodes=parts[-1].nodes.subgroup(lambda n: n.z == n_cubes*h), z=-10 * units.kN, load_case="LL")
+
+# define the outputs
+stp.add_outputs(
+    [DisplacementFieldResults, StressFieldResults]
+)
+
+# ==============================================================================
+# ANALYSIS
+# ==============================================================================
+mdl.analyse_and_extract(problems=[prb], path=TEMP, output=True, max_increments=10, min_inc_size=0.01)
+
+# ==============================================================================
+# RESULTS AND VISUALIZATION
+# ==============================================================================
+# # Show deformed shape
+#Compas Viewer
+stp.show_deformed(scale_results=1000, show_original=0.3, show_loads=0.1)
+#Compas Vedo
+viewer = ModelViewer(model = mdl)
+viewer.add_deformed_shape(step=stp,sf=1000)
+viewer.show(show_parts=True, show_bcs=False)
+
+

--- a/01_tutorials/basic_examples/1D_simple_beam.py
+++ b/01_tutorials/basic_examples/1D_simple_beam.py
@@ -1,0 +1,117 @@
+# Import necessary classes from compas_fea2 for creating the model, materials, and elements
+import os
+import compas_fea2
+
+from compas.geometry import Point, Line
+
+from compas_fea2.model import Model, Part
+from compas_fea2.model import ElasticIsotropic, BeamElement, RectangularSection
+from compas_fea2.problem import (
+    Problem,
+    StaticStep,
+    LoadCombination,
+)
+from compas_fea2.results import DisplacementFieldResults, ReactionFieldResults
+from compas_fea2.units import units
+
+
+#--------------------------------------
+# Backend
+#--------------------------------------
+compas_fea2.set_backend("compas_fea2_castem")
+# compas_fea2.set_backend("compas_fea2_sofistik")
+
+HERE = os.path.dirname(__file__)
+TEMP = os.path.join(HERE, "..", "..", "temp")
+
+#--------------------------------------
+# Units
+#--------------------------------------
+# Define the unit system to be used (SI with millimeters)
+units = units(system="SI_mm")  # SI units with length in millimeters
+
+#--------------------------------------
+# Model
+#--------------------------------------
+# Initialize the main finite element model
+mdl = Model(name="simplebeam")
+
+# Geometry with compas.geometry objects
+lx = 5000
+
+p1 = Point(x = 0, y=0, z=0)
+p2 = Point(x = lx , y=0, z=0) 
+l1 = Line(p1, p2)
+
+# Material and section
+
+mat = ElasticIsotropic(
+    E=10 * units("GPa"),  # Young's modulus (30 GPa)
+    v=0.2,  # Poisson's ratio (dimensionless)
+    density=2500 * units("kg/m**3"),  # Density (2400 kg/m³)
+)
+
+sec = RectangularSection(w= 12 * units.cm, h=10 * units.cm, material= mat)
+
+# Meshing and creation of part with specific method
+prt = Part.from_compas_lines_discretized(lines=[l1], targetlength=10, element_class=BeamElement, section=sec, frame=[0,1,0])
+
+mdl.add_part(prt)
+
+# Meshing and creation of part with specific method
+mdl.add_pin_bc(nodes=prt.find_closest_nodes_to_point(p1))
+mdl.add_pin_bc(nodes=prt.find_closest_nodes_to_point(p2))
+
+# Visualize the geometry 
+# mdl.show()
+
+#--------------------------------------
+# Problem
+#--------------------------------------
+
+# define the problem
+prb = mdl.add_problem(problem=Problem(name="simplebeam"))
+# define a step
+stp = prb.add_step(StaticStep())
+stp.combination = LoadCombination.SLS()
+# Add a uniform load
+stp.add_uniform_node_load(nodes= mdl.nodes, z=-1 * units.kN, load_case="LL")
+# define the outputs
+stp.add_outputs([DisplacementFieldResults, ReactionFieldResults])
+
+#--------------------------------------
+# Analysis
+#--------------------------------------
+
+mdl.analyse_and_extract(problems=[prb], path=TEMP, verbose=True)
+
+#--------------------------------------
+# Visualization
+#--------------------------------------
+disp = stp.displacement_field
+
+stp.show_deformed(scale_results=10, show_original=0.1, show_bcs=0.1)
+
+# stp.show_displacements()
+
+# Print reaction results
+react = stp.reaction_field
+print("Max/Min reaction forces in Z direction [N]: ", 
+      react.get_limits_component('z')[0].magnitude, "/",
+      react.get_limits_component('z')[1].magnitude)
+#--------------------------------------
+# VERIFICATION OF RESULTS
+#--------------------------------------
+
+reaction_vector, applied_load = stp.check_force_equilibrium()
+
+#result from FEA
+
+max_z = stp.displacement_field.get_min_result("z")
+print("Deflection result from FEA model : " +str(max_z.z) + " mm")
+
+#theory
+load_linear = applied_load[2]/lx
+fl = 5/384 * load_linear * lx**4 / (mat.E * sec.Ixx)
+print("Theorical deflection result : " +str(fl) + " mm")
+

--- a/01_tutorials/basic_examples/3D_cylinder.py
+++ b/01_tutorials/basic_examples/3D_cylinder.py
@@ -1,0 +1,141 @@
+# Import necessary classes from compas_fea2 for creating the model, materials, and elements
+import os
+
+from compas.geometry import Point, Line,  Cylinder
+
+from compas_gmsh.models import ShapeModel
+
+import compas_fea2
+from compas_fea2.model import Model, Part
+from compas_fea2.model import ElasticIsotropic, SolidSection
+from compas_fea2.problem import LoadCombination, ConcentratedLoad, NodeLoadField
+from compas_fea2.results import DisplacementFieldResults, SectionForcesFieldResults, ReactionFieldResults
+from compas_fea2_vedo.viewer import ModelViewer
+from compas_fea2.units import units
+
+
+#--------------------------------------
+# Backend
+#--------------------------------------
+compas_fea2.set_backend("compas_fea2_castem")
+# compas_fea2.set_backend("compas_fea2_sofistik")
+
+units = units(system="SI")
+
+HERE = os.path.dirname(__file__)
+TEMP = os.path.join(HERE, "..", "..", "temp")
+
+
+# ==============================================================================
+# Create a cylinder and mesh
+# ==============================================================================
+#geometry parameters
+r = 1
+h = 4
+
+#compas.geometry objects
+pb = Point(0,0,0)
+ph = Point(0,0,h)
+l_height = Line(pb, ph)
+
+#creation of cube (box) object in compas
+cylinder1 = Cylinder.from_line_and_radius(line=l_height, radius=r)
+
+#creation of a gmsh model of the geometry
+print('Beginning of gmsh meshing')
+compasgmsh_model = ShapeModel(name='cylinder1')
+compasgmsh_model.add_cylinder(cylinder1)
+compasgmsh_model.options.mesh.lmax = 0.2
+compasgmsh_model.generate_mesh(3)
+print('End of gmsh meshing')
+
+# ==============================================================================
+# COMPAS_FEA2
+# ==============================================================================
+# Initialize the model
+mdl = Model(name="steel_shell")
+
+# Define material properties
+mat = ElasticIsotropic(E=200000 * units.Pa, v=0.3, density=2500)
+
+# Define the shell section
+sec = SolidSection(material=mat)
+
+# Create a deformable part from the mesh of gmsh
+prt = Part.from_gmsh(gmshModel=compasgmsh_model, section=sec)
+
+mdl.add_part(prt)
+
+
+# Set boundary conditions at both ends of the shell
+# Fix the base
+bottom_nodes = prt.nodes.subgroup(lambda n: n.z == 0)
+mdl.add_fix_bc(nodes=bottom_nodes)
+
+# Print model summary
+# mdl.summary())
+# mdl.show(show_bcs=0.001)
+
+# ==============================================================================
+# Define the problem
+# ==============================================================================
+# define step and combination
+prb = mdl.add_problem(name="cylinder_traction")
+stp = prb.add_static_step()
+stp.combination = LoadCombination.SLS()
+
+# define the loads
+top_nodes = prt.nodes.subgroup(lambda n: n.z == h)
+stp.add_uniform_node_load(nodes=top_nodes, z=1000 * units.N, load_case="LL")
+
+# define the outputs
+stp.add_outputs([DisplacementFieldResults, ReactionFieldResults])
+
+# ==============================================================================
+# Run the analysis and show results
+# ==============================================================================
+# Analyze and extract results to SQLite database
+mdl.analyse_and_extract(
+    problems=[prb], path=os.path.join(TEMP, prb.name), erase_data=True, verbose=True
+)
+
+# Show deformed shape
+#Compas Viewer
+stp.show_deformed(scale_results=100, show_original=0.1, show_bcs=0.5, show_loads=0.1)
+#Vedo Viewer
+viewer = ModelViewer(mdl)
+viewer.add_node_field_results(stp.displacement_field, draw_cmap="viridis", draw_vectors=10)
+# viewer.add_stress_tensors(stress, 1)
+# viewer.add_principal_stress_vectors(stress, 100)
+viewer.show()
+
+# ==============================================================================
+# Results verification
+# ==============================================================================
+# Force equilibrium
+
+reaction_vector, applied_load = stp.check_force_equilibrium()
+fz_tot = applied_load[2]
+
+# Displacements
+# z-axis (height)
+disp = stp.displacement_field.get_result_at(list(top_nodes)[0])
+max_z = stp.displacement_field.get_max_result("z")
+print("Maximum displacement result in z (FEA) "+ str(max_z.z) +" mm")
+
+area = 3.14 *r**2
+eps_z = fz_tot/area/mat.E
+z_th = eps_z*h
+print("Theorical z-displacement value on the top "+ str(z_th) +" mm")
+
+
+# r-axis (radius)
+min_x = stp.displacement_field.get_min_result("x")
+min_y = stp.displacement_field.get_min_result("y")
+print("Minimum displacement result in x (FEA)  : "+ str(min_x.x)+" mm")
+
+eps_r = -mat.v * eps_z
+x_th = eps_r*r
+print("Theorical x-displacement value : "+ str(x_th) +" mm")
+
+

--- a/01_tutorials/constructors/03_plate_from_mesh.py
+++ b/01_tutorials/constructors/03_plate_from_mesh.py
@@ -17,6 +17,7 @@ import os
 
 from compas.datastructures import Mesh
 from compas_gmsh.models import MeshModel
+from compas.geometry import Point, Line
 
 import compas_fea2
 from compas_fea2.model import Model, Part
@@ -109,3 +110,7 @@ viewer.add_node_field_results(
     stp.displacement_field, draw_cmap="viridis", draw_vectors=100
 )
 viewer.show()
+
+#Plot deflection mid-width
+line = Line(Point(0, ly/2, 0), Point(lx, ly/2, 0))
+stp.plot_deflection_along_line(line, n_divide=100)

--- a/01_tutorials/constructors/05_frame_constructor.py
+++ b/01_tutorials/constructors/05_frame_constructor.py
@@ -1,0 +1,116 @@
+"""
+Constructor : Frame
+
+This script presents the frame_constructor function for 1D elements.
+This function generates automatically the frame so as to have a cross section.
+The orientation of the section along the longitudinal axis can be changed with the
+gamma parameter.
+
+The script generates randomly discretized beam models, whose frame have been generated
+with the frame_constructor function.
+"""
+
+from random import random
+
+from compas.geometry import Frame, Point, Line
+
+from compas_fea2.model import (
+    Model,
+    RectangularSection,
+    ElasticIsotropic,
+    BeamElement,
+    Part
+)
+
+
+# Define the model
+mdl = Model(name="frame_constructior")
+
+# Define an elastic isotropic material (e.g., concrete or steel)
+mat = ElasticIsotropic(
+    E=0,  # Young's modulus (30 GPa)
+    v=0,  # Poisson's ratio (dimensionless)
+    density=0,  # Density (2400 kg/m³)
+)
+
+
+vx=(random()*2-1)*10000
+vy=(random()*2-1)*10000
+vz=(random()*2-1)*10000
+# Geometry
+p0 = Point(0,0,0)
+px = Point(1000, 0, 0)
+py = Point(0, 1000, 0)
+pz = Point(0, 0, 1000)
+p1 = Point((random()*2-1)*10000, (random()*2-1)*10000, (random()*2-1)*10000)
+p2 = Point((random()*2-1)*10000, (random()*2-1)*10000, (random()*2-1)*10000)
+p3 = Point((random()*2-1)*10000, (random()*2-1)*10000, (random()*2-1)*10000)
+p4 = Point((random()*2-1)*10000, (random()*2-1)*10000, (random()*2-1)*10000)
+
+
+# Lines
+lines = [
+    Line(px, p0),
+         Line(p0, py),
+         Line(p0, pz),
+        Line(p0, p1),
+        Line(p0, p2),
+        Line(p0, p4),
+        Line(p0, p3)
+]
+
+# Section
+sec = RectangularSection(
+    w=100 ,
+    h=500 ,
+    material=mat
+)
+
+def frame_oriented(line, gamma=0):
+    """
+    Determine the local frame of a line according to its direction.
+    The rotation according to the neutral-axis can be changed with the gamma parameters (radian).
+
+    Parameters
+    ----------
+    line : :class: compas.geometry.Line
+            Compas line defining the neutral axis of the beam.
+    
+    gamma : float (optional)
+            Rotation of the frame along the longitudinal axis.
+            If not indicated, gamma is considered null.
+
+    """
+    from math import atan, pi, asin
+    from numpy import sign
+
+    v = line.vector
+    if v.y== 0 :
+        alpha = -pi/2 *sign(v.x)
+        if v.x==0:
+            beta = pi/2
+        else :
+            beta = asin(v.z/v.length)
+    else :
+        alpha = -atan(v.x/v.y) 
+
+        beta = asin(v.z/v.length)*v.y/abs(v.y)
+    
+    f = Frame.from_euler_angles(
+        euler_angles=[alpha , beta, gamma],
+        static=False,
+        axes="zxy",
+        point=line.start,
+    )
+    return f
+
+
+# Define the beams
+parts = []
+for line in lines :
+    prt = parts.append(Part.from_compas_lines_discretized([line], 1000, BeamElement, sec, frame_oriented(line, gamma=0)))
+mdl.add_parts(parts)
+
+#In visualization, the smaller beams are the ones directed according to the x-, y-, and z-axis
+#The longer ones are generated randomly
+mdl.show()


### PR DESCRIPTION
Implementation of new examples :
- 1D_simple_beam.py 
 Example of a simply supported beam (1D) with distributed loading. The FEA results of deflection are compared with the theorical results.
 
- 3D_cylinder.py
Example of a 3D cylinder fixed at its base, whose top is loaded with traction. The FEA results of displacements are compared with the theorical results.

- 05_frame_constructor
Constructor of frame for 1D element so as to have easily the right cross section for a beam.

- connector_rooftimber.py 
Example of a roof timber, showing how to articulate different parts (connectors)

- interface_stackedcubes.py
Example of several cubes that are stacked on top of each other. The behaviour between cubes is dealt with interfaces.

These examples are using newly created method that have just been pushed on compas_fea2 repository.
